### PR TITLE
fix: fix layout convergence error

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -4,7 +4,7 @@
   show reg: it => context {
     let todo = it.text.match(reg).captures.at(0).trim()
     let here = here()
-    todo-list.update(lst => ((todo, here),))
+    todo-list.update(lst => lst + ((todo, here),))
     highlight(fill: color)[TODO: #todo]
   }
 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -1,13 +1,10 @@
 #let tally(body, color: yellow) = {
   let todo-list = state("todo-list", ())
-  let reg = regex("TODO:.+")
+  let reg = regex("TODO:(.+)")
   show reg: it => context {
-    let todos = it
-      .text
-      .matches(regex("TODO:"))
-      .map(t => it.text.slice(t.end).trim(reg).trim())
-    todo-list.update(todo-list.get() + todos.map(it => (it, here())))
-    todos.map(it => highlight(fill: color)[TODO: #it ]).join()
+    let todo = it.text.match(reg).captures.at(0).trim()
+    todo-list.update(lst => lst.push(todo))
+    highlight(fill: color)[TODO: #todo]
   }
 
   body

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -3,7 +3,8 @@
   let reg = regex("TODO:(.+)")
   show reg: it => context {
     let todo = it.text.match(reg).captures.at(0).trim()
-    todo-list.update(lst => lst.push(todo))
+    let here = here()
+    todo-list.update(lst => ((todo, here),))
     highlight(fill: color)[TODO: #todo]
   }
 


### PR DESCRIPTION
Hi, and thanks for the great package!

I encountered an issue where having more than five "TODO: " items triggers `a layout did not converge within 5 attempts` warning.
The problem was caused by getting state inside the update method. I resolved this by passing a function instead.

Additionally, I simplified the logic by using regex capture groups to make it cleaner.

Please take a look when you have a chance. Feedback is welcome!